### PR TITLE
chore: development release on develop branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,6 +3,9 @@ name: Publish
 on:
   release:
     types: ["published"]
+  push:
+    branches:
+      - develop
 
 jobs:
   run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blazefl"
-version = "1.1.0"
+version = "2.0.0.dev1"
 description = "A blazing-fast and lightweight simulation framework for Federated Learning."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -82,7 +82,7 @@ wheels = [
 
 [[package]]
 name = "blazefl"
-version = "1.1.0"
+version = "2.0.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
## WHAT

This PR enables automatic development releases from the `develop` branch. The version in `pyproject.toml` should be set to a development version (e.g., `x.y.z.dev1`).

ref: [Versioning \- Python Packaging User Guide](https://packaging.python.org/en/latest/discussions/versioning/)

## WHY

This allows us to test experimental features that require importing the project as an installed package.