### PR TITLE
docs: include optional packages

### DIFF
--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -21,7 +21,7 @@ jobs:
         run: uv python install
 
       - name: Install the project
-        run: uv sync --group docs
+        run: uv sync --all-extras --group docs
 
       - run: uv run sphinx-build -M html docs/source docs/build
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,9 @@ release = importlib.metadata.version(project)
 import sys  # noqa: E402
 from pathlib import Path  # noqa: E402
 
-sys.path.insert(0, str(Path("../../src").resolve()))
+sys.path.insert(0, str(Path("../../src/blazefl/core").resolve()))
+sys.path.insert(0, str(Path("../../src/blazefl/contrib").resolve()))
+sys.path.insert(0, str(Path("../../src/blazefl/reproducibility").resolve()))
 
 extensions = [
     "sphinx.ext.napoleon",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,9 +19,7 @@ release = importlib.metadata.version(project)
 import sys  # noqa: E402
 from pathlib import Path  # noqa: E402
 
-sys.path.insert(0, str(Path("../../src/blazefl/core").resolve()))
-sys.path.insert(0, str(Path("../../src/blazefl/contrib").resolve()))
-sys.path.insert(0, str(Path("../../src/blazefl/reproducibility").resolve()))
+sys.path.insert(0, str(Path("../../src").resolve()))
 
 extensions = [
     "sphinx.ext.napoleon",

--- a/tests/test_contrib/test_fedavg.py
+++ b/tests/test_contrib/test_fedavg.py
@@ -416,6 +416,7 @@ def test_base_handler_and_thread_pool_trainer_integration_keyboard_interrupt(
             )
         time.sleep(0.1)
     assert proc.is_alive()
+    time.sleep(3)
 
     os.kill(proc.pid, signal.SIGINT)
 


### PR DESCRIPTION
## WHAT

This PR updates the `Install the project` step in the `.github/workflows/sphinx.yaml` file by adding the `--all-extras` flag in the `uv sync` command. This change ensures all optional dependencies are installed, allowing the Sphinx documentation to build successfully

## WHY

The Sphinx documentation build was failing in the CI workflow, as shown in [this log](https://github.com/kitsuyaazuma/blazefl/actions/runs/16173490916/job/45652729359).

The build process failed because it couldn't import the `blazefl.contrib` and `blazefl.reproducibility` modules. These modules depend on optional dependencies (`numpy`, `tqdm`) that were not being installed by the previous command, leading to the following `ModuleNotFoundError`:

```
WARNING: [autosummary] failed to import blazefl.contrib.
Possible hints:
* ModuleNotFoundError: No module named 'numpy'
* ImportError: 
* AttributeError: module 'blazefl' has no attribute 'contrib'
WARNING: [autosummary] failed to import blazefl.reproducibility.
Possible hints:
* AttributeError: module 'blazefl' has no attribute 'reproducibility'
* ModuleNotFoundError: No module named 'numpy'
* ImportError: 
```

This change resolves the issue by ensuring all necessary dependencies are present during the build.
