### PR TITLE
refactor: use strenum for ipc mode

### DIFF
--- a/src/blazefl/contrib/fedavg.py
+++ b/src/blazefl/contrib/fedavg.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from enum import StrEnum
 from multiprocessing.pool import ApplyResult
 from pathlib import Path
-from typing import Literal
 
 import torch
 import torch.multiprocessing as mp
@@ -15,14 +14,15 @@ from tqdm import tqdm
 from blazefl.core import (
     BaseClientTrainer,
     BaseServerHandler,
+    IPCMode,
     ModelSelector,
     PartitionedDataset,
     ProcessPoolClientTrainer,
+    SHMHandle,
     ThreadPoolClientTrainer,
     deserialize_model,
     serialize_model,
 )
-from blazefl.core.utils import SHMHandle
 from blazefl.reproducibility import (
     RNGSuite,
     create_rng_suite,
@@ -503,7 +503,7 @@ class FedAvgProcessPoolClientTrainer(
         lr: float,
         seed: int,
         num_parallels: int,
-        ipc_mode: Literal["storage", "shared_memory"],
+        ipc_mode: IPCMode,
     ) -> None:
         """
         Initialize the FedAvgParalleClientTrainer.

--- a/src/blazefl/core/__init__.py
+++ b/src/blazefl/core/__init__.py
@@ -7,6 +7,7 @@ including client trainers, model selectors, partitioned datasets, and server han
 
 from blazefl.core.client_trainer import (
     BaseClientTrainer,
+    IPCMode,
     ProcessPoolClientTrainer,
     ThreadPoolClientTrainer,
 )
@@ -26,6 +27,7 @@ __all__ = [
     "FilteredDataset",
     "ProcessPoolClientTrainer",
     "ThreadPoolClientTrainer",
+    "IPCMode",
     "ModelSelector",
     "PartitionedDataset",
     "BaseServerHandler",

--- a/src/blazefl/core/__init__.pyi
+++ b/src/blazefl/core/__init__.pyi
@@ -1,7 +1,7 @@
-from blazefl.core.client_trainer import BaseClientTrainer as BaseClientTrainer, ProcessPoolClientTrainer as ProcessPoolClientTrainer, ThreadPoolClientTrainer as ThreadPoolClientTrainer
+from blazefl.core.client_trainer import BaseClientTrainer as BaseClientTrainer, IPCMode as IPCMode, ProcessPoolClientTrainer as ProcessPoolClientTrainer, ThreadPoolClientTrainer as ThreadPoolClientTrainer
 from blazefl.core.model_selector import ModelSelector as ModelSelector
 from blazefl.core.partitioned_dataset import FilteredDataset as FilteredDataset, PartitionedDataset as PartitionedDataset
 from blazefl.core.server_handler import BaseServerHandler as BaseServerHandler
 from blazefl.core.utils import SHMHandle as SHMHandle, deserialize_model as deserialize_model, process_tensors_in_object as process_tensors_in_object, reconstruct_from_shared_memory as reconstruct_from_shared_memory, serialize_model as serialize_model
 
-__all__ = ['BaseClientTrainer', 'FilteredDataset', 'ProcessPoolClientTrainer', 'ThreadPoolClientTrainer', 'ModelSelector', 'PartitionedDataset', 'BaseServerHandler', 'serialize_model', 'deserialize_model', 'process_tensors_in_object', 'reconstruct_from_shared_memory', 'SHMHandle']
+__all__ = ['BaseClientTrainer', 'FilteredDataset', 'ProcessPoolClientTrainer', 'ThreadPoolClientTrainer', 'IPCMode', 'ModelSelector', 'PartitionedDataset', 'BaseServerHandler', 'serialize_model', 'deserialize_model', 'process_tensors_in_object', 'reconstruct_from_shared_memory', 'SHMHandle']

--- a/src/blazefl/core/client_trainer.pyi
+++ b/src/blazefl/core/client_trainer.pyi
@@ -2,9 +2,10 @@ import threading
 from blazefl.core.utils import process_tensors_in_object as process_tensors_in_object, reconstruct_from_shared_memory as reconstruct_from_shared_memory
 from collections.abc import Iterable
 from concurrent.futures import Future as Future
+from enum import StrEnum
 from multiprocessing.pool import ApplyResult as ApplyResult
 from pathlib import Path
-from typing import Literal, Protocol, TypeVar
+from typing import Protocol, TypeVar
 
 UplinkPackage = TypeVar('UplinkPackage')
 DownlinkPackage = TypeVar('DownlinkPackage', contravariant=True)
@@ -14,13 +15,17 @@ class BaseClientTrainer(Protocol[UplinkPackage, DownlinkPackage]):
     def local_process(self, payload: DownlinkPackage, cid_list: list[int]) -> None: ...
 ClientConfig = TypeVar('ClientConfig')
 
+class IPCMode(StrEnum):
+    STORAGE: str
+    SHARED_MEMORY: str
+
 class ProcessPoolClientTrainer(BaseClientTrainer[UplinkPackage, DownlinkPackage], Protocol[UplinkPackage, DownlinkPackage, ClientConfig]):
     num_parallels: int
     share_dir: Path
     device: str
     device_count: int
     cache: list[UplinkPackage]
-    ipc_mode: Literal['storage', 'shared_memory']
+    ipc_mode: IPCMode
     stop_event: threading.Event
     def progress_fn(self, it: list[ApplyResult]) -> Iterable[ApplyResult]: ...
     def get_client_config(self, cid: int) -> ClientConfig: ...

--- a/tests/test_contrib/test_fedavg.py
+++ b/tests/test_contrib/test_fedavg.py
@@ -10,6 +10,7 @@ import torch
 import torch.multiprocessing as mp
 from torch.utils.data import DataLoader, Dataset
 
+from blazefl.core.client_trainer import IPCMode
 from src.blazefl.contrib.fedavg import (
     FedAvgBaseClientTrainer,
     FedAvgBaseServerHandler,
@@ -170,7 +171,7 @@ def _run_process_pool_trainer(
         trainer.local_process(downlink, cids)
 
 
-@pytest.mark.parametrize("ipc_mode", ["storage", "shared_memory"])
+@pytest.mark.parametrize("ipc_mode", [IPCMode.STORAGE, IPCMode.SHARED_MEMORY])
 def test_base_handler_and_process_pool_trainer_integration(
     model_selector, partitioned_dataset, device, tmp_share_dir, tmp_state_dir, ipc_mode
 ):

--- a/tests/test_core/test_client_trainer.py
+++ b/tests/test_core/test_client_trainer.py
@@ -1,12 +1,12 @@
 import threading
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
 
 import pytest
 import torch
 import torch.multiprocessing as mp
 
+from blazefl.core.client_trainer import IPCMode
 from blazefl.core.utils import SHMHandle
 from src.blazefl.core import ProcessPoolClientTrainer
 
@@ -36,7 +36,7 @@ class DummyProcessPoolClientTrainer(
         num_parallels: int,
         share_dir: Path,
         device: str,
-        ipc_mode: Literal["storage", "shared_memory"],
+        ipc_mode: IPCMode,
     ):
         self.num_parallels = num_parallels
         self.share_dir = share_dir
@@ -122,7 +122,7 @@ def test_process_pool_client_trainer(
     tmp_path: Path,
     num_parallels: int,
     cid_list: list[int],
-    ipc_mode: Literal["storage", "shared_memory"],
+    ipc_mode: IPCMode,
 ) -> None:
     trainer = DummyProcessPoolClientTrainer(
         num_parallels=num_parallels,


### PR DESCRIPTION
## WHAT

This PR replaces the `Literal` type for IPC mode with a more robust `IPCMode(StrEnum)`. This simplifies type hinting.

## WHY

This refactoring improves type-safety, readability, and maintainability by replacing magic strings with a clear `Enum`.

It is fully backward-compatible, as `StrEnum` still accepts raw string values, ensuring no breaking changes for users.