### PR TITLE
chore: migrate repository to kitsuyaazuma/blazefl

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Kitsuya Azuma
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center"><img src="https://raw.githubusercontent.com/blazefl/blazefl/refs/heads/main/docs/imgs/logo.svg" width=600></div>
+<div align="center"><img src="https://raw.githubusercontent.com/kitsuyaazuma/blazefl/refs/heads/main/docs/imgs/logo.svg" width=600></div>
 <div align="center">A blazing-fast, minimalist, and researcher-friendly simulation framework for Federated Learning</div>
 <br>
 <div align="center">
@@ -154,8 +154,8 @@ uv add blazefl
 
 | Example | Description | 
 |---------|-------------|
-| [Quickstart: FedAvg](https://github.com/blazefl/blazefl/tree/main/examples/quickstart-fedavg) | Learn the fundamentals of BlazeFL with a standard Federated Averaging (FedAvg) implementation, covering single-threaded, multi-process, and multi-threaded modes. |
-| [Step-by-Step Tutorial: DS-FL](https://github.com/blazefl/blazefl/tree/main/examples/step-by-step-dsfl) | Build a custom distillation-based Federated Learning algorithm from scratch, and understand how to implement your own algorithms on the BlazeFL framework. |
+| [Quickstart: FedAvg](https://github.com/kitsuyaazuma/blazefl/tree/main/examples/quickstart-fedavg) | Learn the fundamentals of BlazeFL with a standard Federated Averaging (FedAvg) implementation, covering single-threaded, multi-process, and multi-threaded modes. |
+| [Step-by-Step Tutorial: DS-FL](https://github.com/kitsuyaazuma/blazefl/tree/main/examples/step-by-step-dsfl) | Build a custom distillation-based Federated Learning algorithm from scratch, and understand how to implement your own algorithms on the BlazeFL framework. |
 
 
 ## Robust Reproducibility
@@ -332,8 +332,8 @@ The benchmark was conducted on a single node with the following specifications:
 The results demonstrate that BlazeFL's multi-threaded mode is the clear winner, outperforming both its own multi-process mode and Flower in nearly all scenarios.
 
 <div style="display: flex; justify-content: center; align-items: center;">
-  <img src="https://raw.githubusercontent.com/blazefl/blazefl/refs/heads/main/docs/imgs/benchmark_cnn.png" alt="CNN" width="48%" />
-  <img src="https://raw.githubusercontent.com/blazefl/blazefl/refs/heads/main/docs/imgs/benchmark_resnet18.png" alt="ResNet18" width="48%" />
+  <img src="https://raw.githubusercontent.com/kitsuyaazuma/blazefl/refs/heads/main/docs/imgs/benchmark_cnn.png" alt="CNN" width="48%" />
+  <img src="https://raw.githubusercontent.com/kitsuyaazuma/blazefl/refs/heads/main/docs/imgs/benchmark_resnet18.png" alt="ResNet18" width="48%" />
 </div>
 <br>
 
@@ -343,6 +343,6 @@ This benchmark highlights the power of free-threaded Python for CPU-bound, data-
 
 ## Contributing
 
-We welcome contributions from the community! If you'd like to contribute to this project, please see our [contribution guidelines](https://github.com/blazefl/blazefl/blob/main/docs/source/contribute.rst) for more information on how to get started.
+We welcome contributions from the community! If you'd like to contribute to this project, please see our [contribution guidelines](https://github.com/kitsuyaazuma/blazefl/blob/main/docs/source/contribute.rst) for more information on how to get started.
 
-Please note that this project is governed by our [Code of Conduct](https://github.com/blazefl/blazefl/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+Please note that this project is governed by our [Code of Conduct](https://github.com/kitsuyaazuma/blazefl/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```bash
-git clone https://github.com/blazefl/blazefl.git
+git clone https://github.com/kitsuyaazuma/blazefl.git
 cd blazefl/benchmarks
 
 uv sync

--- a/benchmarks/blazefl-case/README.md
+++ b/benchmarks/blazefl-case/README.md
@@ -1,11 +1,11 @@
 # Benchmark: BlazeFL
 
-This benchmark measures the performance of [BlazeFL](https://github.com/blazefl/blazefl).
+This benchmark measures the performance of [BlazeFL](https://github.com/kitsuyaazuma/blazefl).
 
 ## Setup
 
 ```bash
-git clone https://github.com/blazefl/blazefl.git
+git clone https://github.com/kitsuyaazuma/blazefl.git
 cd blazefl/benchmarks/blazefl-case
 
 uv sync

--- a/benchmarks/flower-case/README.md
+++ b/benchmarks/flower-case/README.md
@@ -5,7 +5,7 @@ This benchmark measures the performance of [Flower](https://github.com/adap/flow
 ## Setup
 
 ```bash
-git clone https://github.com/blazefl/blazefl.git
+git clone https://github.com/kitsuyaazuma/blazefl.git
 cd blazefl/benchmarks/flower-case
 
 uv sync

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,7 @@ import importlib.metadata
 
 project = "blazefl"
 author = "kitsuyaazuma"
-copyright = f"2025, {author}"
+copyright = f"2026, {author}"
 release = importlib.metadata.version(project)
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/contribute.rst
+++ b/docs/source/contribute.rst
@@ -22,7 +22,7 @@ We gladly accept pull requests! Before submitting a pull request, please ensure 
 Code of Conduct
 ---------------
 
-Please note that this project is governed by our `Code of Conduct <https://github.com/blazefl/blazefl/blob/main/CODE_OF_CONDUCT.md>`_.
+Please note that this project is governed by our `Code of Conduct <https://github.com/kitsuyaazuma/blazefl/blob/main/CODE_OF_CONDUCT.md>`_.
 By participating, you are expected to uphold this code. Please report any unacceptable behavior.
 
 Thank you for contributing to our project!

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ BlazeFL Documentation
 
 - 🛡️ **Structured and Type-Safe by Design**: By leveraging `dataclasses <https://docs.python.org/3/library/dataclasses.html>`_ and `protocols <https://typing.python.org/en/latest/spec/protocol.html>`_, BlazeFL enables the creation of clear, type-safe, and self-documenting communication packages (``UplinkPackage``, ``DownlinkPackage``). This design enhances code readability, maintainability, and reduces errors in FL workflows.
 
-For a comprehensive overview, including detailed execution modes, benchmarks, and setup examples, please refer to the `README.md <https://github.com/blazefl/blazefl/blob/main/README.md>`_ on our GitHub repository.
+For a comprehensive overview, including detailed execution modes, benchmarks, and setup examples, please refer to the `README.md <https://github.com/kitsuyaazuma/blazefl/blob/main/README.md>`_ on our GitHub repository.
 
 .. toctree::
    :maxdepth: 1

--- a/examples/quickstart-fedavg/README.md
+++ b/examples/quickstart-fedavg/README.md
@@ -9,7 +9,7 @@ Welcome to the quickstart guide for the Federated Averaging (FedAvg [^1]) with B
 First, clone the BlazeFL repository and navigating to the `quickstart-fedavg` directory:
 
 ```bash
-git clone https://github.com/blazefl/blazefl.git
+git clone https://github.com/kitsuyaazuma/blazefl.git
 cd blazefl/examples/quickstart-fedavg
 ```
 

--- a/examples/step-by-step-dsfl/README.md
+++ b/examples/step-by-step-dsfl/README.md
@@ -107,7 +107,7 @@ Meanwhile, `get_dataloader` wraps that dataset in a `DataLoader`.
 This design is flexible enough even for methods like DS-FL, which rely on an open dataset.
 If you don’t need one of these methods, you can simply implement it with `pass`.
 
-You can view the complete source code [here](https://github.com/blazefl/blazefl/tree/main/examples/step-by-step-dsfl/dataset).
+You can view the complete source code [here](https://github.com/kitsuyaazuma/blazefl/tree/main/examples/step-by-step-dsfl/dataset).
 
 ## Implementing a ModelSelector
 
@@ -143,7 +143,7 @@ class DSFLModelSelector(ModelSelector[DSFLModelName]):
 Here, we define model names using `StrEnum` for better type safety. The `select_model` method then takes a `DSFLModelName` and returns the corresponding `nn.Module`.
 You can store useful information (like the number of classes) as attributes in your `ModelSelector`.
 
-The full source code can be found [here](https://github.com/blazefl/blazefl/tree/main/examples/step-by-step-dsfl/models).
+The full source code can be found [here](https://github.com/kitsuyaazuma/blazefl/tree/main/examples/step-by-step-dsfl/models).
 
 ## Defining DownlinkPackage and UplinkPackage
 
@@ -270,7 +270,7 @@ If any of these methods are not needed for your approach, you can simply impleme
 
 In DS-FL, the `global_update` method aggregates the soft labels from clients and distills them into a global model.
 However, you have the flexibility to place any custom operations in these or other methods.
-You can find more details in the [official documentation](https://blazefl.github.io/blazefl/generated/blazefl.core.BaseServerHandler.html#blazefl.core.BaseServerHandler).
+You can find more details in the [official documentation](https://kitsuyaazuma.github.io/blazefl/generated/blazefl.core.BaseServerHandler.html#blazefl.core.BaseServerHandler).
 
 
 ## Implementing a ThreadPoolClientTrainer
@@ -410,7 +410,7 @@ This class uses Python’s `threading` library (wrapped under BlazeFL) to train 
 
 Unlike process-based training, threads share the same memory space, making it easy to manage state using a simple dictionary (`self.client_states`) without complex serialization.
 
-The complete source code is [here](https://github.com/blazefl/blazefl/tree/main/examples/step-by-step-dsfl/algorithm/dsfl.py).
+The complete source code is [here](https://github.com/kitsuyaazuma/blazefl/tree/main/examples/step-by-step-dsfl/algorithm/dsfl.py).
 
 ## Implementing a Pipeline
 
@@ -456,7 +456,7 @@ This pipeline is almost identical to one you might create for FedAvg or another 
 
 In this snippet, we use [W&B](https://github.com/wandb/wandb) for logging, but you’re free to use alternatives like TensorBoard.
 
-You can see the full source code [here](https://github.com/blazefl/blazefl/tree/main/examples/step-by-step-dsfl/main.py).
+You can see the full source code [here](https://github.com/kitsuyaazuma/blazefl/tree/main/examples/step-by-step-dsfl/main.py).
 
 ## Running the Simulation
 

--- a/src/blazefl/core/client_trainer.py
+++ b/src/blazefl/core/client_trainer.py
@@ -54,16 +54,17 @@ class ProcessPoolClientTrainer(
     Protocol[UplinkPackage, DownlinkPackage, ClientConfig],
 ):
     """
-    Abstract base class for parallel client training in federated learning.
+    Abstract base class for parallel client training using a process pool.
 
-    This class extends SerialClientTrainer to enable parallel processing of clients,
-    allowing multiple clients to be trained concurrently.
+    This class enables parallel processing of clients by distributing tasks across
+    multiple processes.
 
     Attributes:
-        num_parallels (int): Number of parallel processes to use for client training.
-        device (str): The primary device to use for computation (e.g., "cpu", "cuda").
-        device_count (int): The number of available CUDA devices, if `device` is "cuda".
-        cache (list[UplinkPackage]): Cache to store uplink packages from clients.
+        num_parallels (int): Number of parallel processes to use.
+        device (str): Primary device for computation (e.g., "cpu", "cuda").
+        device_count (int): Number of available CUDA devices for distribution.
+        cache (list[UplinkPackage]): Cache to store results from clients.
+        stop_event (threading.Event): Event to signal workers to stop.
 
     Raises:
         NotImplementedError: If the abstract methods are not implemented in a subclass.
@@ -216,6 +217,22 @@ class ThreadPoolClientTrainer(
     BaseClientTrainer[UplinkPackage, DownlinkPackage],
     Protocol[UplinkPackage, DownlinkPackage],
 ):
+    """
+    Abstract base class for parallel client training using a thread pool.
+
+    This class enables parallel processing of clients within a processes.
+
+    Attributes:
+        num_parallels (int): Number of parallel threads to use.
+        device (str): Primary device for computation (e.g., "cpu", "cuda").
+        device_count (int): Number of available CUDA devices for distribution.
+        cache (list[UplinkPackage]): Cache to store results from clients.
+        stop_event (threading.Event): Event to signal workers to stop.
+
+    Raises:
+        NotImplementedError: If the abstract methods are not implemented in a subclass.
+    """
+
     num_parallels: int
     device: str
     device_count: int


### PR DESCRIPTION
## WHAT

This PR updates all repository references and links from `blazefl/blazefl` to `kitsuyaazuma/blazefl`.

## WHY

The repository is being moved to the developer's personal account as he is transitioning away from active Federated Learning research and will have limited time for major new feature development.